### PR TITLE
Add project workflow models and marketplace

### DIFF
--- a/main/migrations/0012_steps.py
+++ b/main/migrations/0012_steps.py
@@ -1,0 +1,59 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def create_etapes(apps, schema_editor):
+    Etape = apps.get_model('main', 'Etape')
+    noms = [
+        'Définition',
+        'Recherche',
+        'Devis',
+        'Négociation',
+        'Remise des clés',
+        'Estimation',
+        'Diagnostics',
+        'Valorisation',
+        'Commercialisation',
+        'Post-vente',
+    ]
+    for ordre, nom in enumerate(noms, start=1):
+        Etape.objects.create(nom=nom, ordre=ordre)
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0011_projets'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='professionnel',
+            name='localisation',
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name='projets',
+            name='professionnel',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='projets', to='main.professionnel'),
+        ),
+        migrations.CreateModel(
+            name='Etape',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('nom', models.CharField(max_length=100)),
+                ('ordre', models.PositiveIntegerField()),
+            ],
+            options={'ordering': ['ordre']},
+        ),
+        migrations.CreateModel(
+            name='ProjetEtape',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('terminee', models.BooleanField(default=False)),
+                ('etape', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.etape')),
+                ('projet', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='etapes', to='main.projets')),
+            ],
+            options={'unique_together': {('projet', 'etape')}},
+        ),
+        migrations.RunPython(create_etapes),
+    ]

--- a/main/models.py
+++ b/main/models.py
@@ -22,6 +22,7 @@ class Professionnel(models.Model):
     siret = models.CharField(max_length=14)
     email_pro = models.EmailField()
     secteur_activite = models.CharField(max_length=100, null=True, blank=True)
+    localisation = models.CharField(max_length=100, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
@@ -131,5 +132,54 @@ class Projets(models.Model):
 
     date_creation = models.DateTimeField(auto_now_add=True)
 
+    professionnel = models.ForeignKey(
+        Professionnel,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="projets"
+    )
+
     def __str__(self):
         return f"{self.utilisateur} - {self.get_type_projet_display()} - {self.get_type_bien_display()}"
+
+    def assign_professionnel(self):
+        if not self.professionnel:
+            pro = Professionnel.objects.filter(
+                secteur_activite__icontains=self.type_projet,
+            )
+            if self.localisation:
+                pro = pro.filter(localisation__icontains=self.localisation)
+            self.professionnel = pro.first()
+
+    def save(self, *args, **kwargs):
+        creating = self._state.adding
+        self.assign_professionnel()
+        super().save(*args, **kwargs)
+        if creating:
+            for etape in Etape.objects.all():
+                ProjetEtape.objects.create(projet=self, etape=etape)
+
+
+class Etape(models.Model):
+    nom = models.CharField(max_length=100)
+    ordre = models.PositiveIntegerField()
+
+    class Meta:
+        ordering = ["ordre"]
+
+    def __str__(self):
+        return self.nom
+
+
+class ProjetEtape(models.Model):
+    projet = models.ForeignKey(Projets, on_delete=models.CASCADE, related_name="etapes")
+    etape = models.ForeignKey(Etape, on_delete=models.CASCADE)
+    terminee = models.BooleanField(default=False)
+
+    class Meta:
+        unique_together = ("projet", "etape")
+
+    def __str__(self):
+        return f"{self.projet} - {self.etape}"
+

--- a/main/templates/blog/marketplace.html
+++ b/main/templates/blog/marketplace.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-4">
+  <h1 class="mb-4">Marketplace des professionnels</h1>
+  <form method="get" class="mb-3 row g-2">
+    <div class="col">
+      <input type="text" name="secteur" placeholder="Secteur" value="{{request.GET.secteur}}" class="form-control">
+    </div>
+    <div class="col">
+      <input type="text" name="localisation" placeholder="Localisation" value="{{request.GET.localisation}}" class="form-control">
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary">Filtrer</button>
+    </div>
+  </form>
+  <table class="table table-striped">
+    <thead>
+      <tr><th>Société</th><th>Secteur</th><th>Localisation</th></tr>
+    </thead>
+    <tbody>
+      {% for pro in professionnels %}
+      <tr>
+        <td>{{ pro.nom_societe }}</td>
+        <td>{{ pro.secteur_activite }}</td>
+        <td>{{ pro.localisation }}</td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="3">Aucun professionnel trouvé.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}

--- a/main/templates/blog/projet_detail.html
+++ b/main/templates/blog/projet_detail.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-4">
+  <h1>{{ projet.get_type_projet_display }} - {{ projet.get_type_bien_display }}</h1>
+  <p><strong>Budget:</strong> {{ projet.budget }} €</p>
+  <p><strong>Localisation:</strong> {{ projet.localisation }}</p>
+  <h3 class="mt-3">Avancement</h3>
+  <ul class="list-group">
+    {% for pe in etapes %}
+    <li class="list-group-item d-flex justify-content-between align-items-center">
+      {{ pe.etape.nom }}
+      {% if pe.terminee %}
+      <span class="badge text-bg-success">✔</span>
+      {% else %}
+      <span class="badge text-bg-secondary">En cours</span>
+      {% endif %}
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock %}

--- a/main/urls.py
+++ b/main/urls.py
@@ -33,6 +33,8 @@ urlpatterns = [
     path('index', views.index, name='index'),
     path('parcours', views.parcours, name='parcours'),
     path('profession', views.profession, name='profession'),
+    path('marketplace/', views.marketplace, name='marketplace'),
+    path('projet/<int:projet_id>/', views.projet_detail, name='projet_detail'),
     
     path('inscription/etape1/', views.inscription_etape1, name='inscription_etape1'),
     path('inscription/etape2/', views.inscription_etape2, name='inscription_etape2'),

--- a/main/views.py
+++ b/main/views.py
@@ -265,3 +265,22 @@ def dashboard(request):
         'nb_contrats': nb_contrats,
         'taux_conversion': taux_conversion,
     })
+
+
+@login_required
+def marketplace(request):
+    secteur = request.GET.get('secteur')
+    localisation = request.GET.get('localisation')
+    pros = Professionnel.objects.all()
+    if secteur:
+        pros = pros.filter(secteur_activite__icontains=secteur)
+    if localisation:
+        pros = pros.filter(localisation__icontains=localisation)
+    return render(request, 'blog/marketplace.html', {'professionnels': pros})
+
+
+@login_required
+def projet_detail(request, projet_id):
+    projet = get_object_or_404(Projets, id=projet_id, utilisateur=request.user)
+    etapes = projet.etapes.select_related('etape')
+    return render(request, 'blog/projet_detail.html', {'projet': projet, 'etapes': etapes})


### PR DESCRIPTION
## Summary
- add localisation to `Professionnel`
- link each `Projets` to a `Professionnel` and auto assign
- create `Etape` and `ProjetEtape` models to track project steps
- create migration to add new models and default steps
- add marketplace and project detail views
- expose new routes
- add simple templates for marketplace and project progress

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: no network access)*