### PR TITLE
Fix add_class filter issue

### DIFF
--- a/main/templates/test/Connection.html
+++ b/main/templates/test/Connection.html
@@ -1,3 +1,4 @@
+{% load form_tags %}
 <!DOCTYPE html>
 <html lang="fr">
   <head>

--- a/main/templatetags/form_tags.py
+++ b/main/templatetags/form_tags.py
@@ -1,0 +1,10 @@
+from django import template
+
+register = template.Library()
+
+@register.filter(name='add_class')
+def add_class(field, css):
+    """Add CSS class(es) to a form field widget."""
+    existing = field.field.widget.attrs.get('class', '')
+    new_classes = (existing + ' ' + css).strip()
+    return field.as_widget(attrs={**field.field.widget.attrs, 'class': new_classes})


### PR DESCRIPTION
## Summary
- add `add_class` filter implementation
- load the filter in `Connection.html`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*